### PR TITLE
Force the Invoke-RestMethod PowerShell cmdlet to use TLS 1.2

### DIFF
--- a/Task/New-TfsGitTag.ps1
+++ b/Task/New-TfsGitTag.ps1
@@ -1,4 +1,5 @@
 [CmdletBinding()]
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 param ()
 
 $OAuthToken = Get-VstsTaskVariable -Name System.AccessToken


### PR DESCRIPTION
TLS 1.0 and TLS 1.1 support for Azure DevOps was disabled on March 31, 2020